### PR TITLE
Use multistage build to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # modules.
 ##################################################
 
-FROM alpine:edge
+FROM alpine:edge AS builder
 
 ENV NGINX_VERSION 1.16.1
 ENV NGX_BROTLI_COMMIT e505dce68acc190cc5a1e780a3b0275e39f160ca
@@ -171,14 +171,40 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
   && apk del .build-deps \
   && apk del .brotli-build-deps \
   && apk del .gettext \
-  && mv /tmp/envsubst /usr/local/bin/ \
-  \
+  && mv /tmp/envsubst /usr/local/bin/
+
+# Create self-signed certificate
+RUN apk add openssl \
+  && openssl req -x509 -newkey rsa:4096 -nodes -keyout /etc/ssl/private/localhost.key -out /etc/ssl/localhost.pem -days 365 -sha256 -subj '/CN=localhost'
+
+
+FROM alpine:latest
+
+COPY --from=builder /usr/sbin/nginx /usr/sbin/nginx-debug /usr/sbin/
+COPY --from=builder /usr/lib/nginx /usr/lib/
+COPY --from=builder /usr/share/nginx/html/* /usr/share/nginx/html/
+COPY --from=builder /etc/nginx/* /etc/nginx/
+COPY --from=builder /usr/local/bin/envsubst /usr/local/bin/
+COPY --from=builder /etc/ssl/private/localhost.key /etc/ssl/private/
+COPY --from=builder /etc/ssl/localhost.pem /etc/ssl/
+
+RUN \
   # Bring in tzdata so users could set the timezones through the environment
   # variables
-  && apk add --no-cache tzdata \
+  apk add --no-cache tzdata \
   \
+  && apk add --no-cache \
+  pcre \
+  libgcc \
+  && addgroup -S nginx \
+  && adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx nginx \
   # forward request and error logs to docker log collector
+  && mkdir -p /var/log/nginx \
+  && touch /var/log/nginx/access.log /var/log/nginx/error.log \
+  && chown nginx: /var/log/nginx/access.log /var/log/nginx/error.log \
   && ln -sf /dev/stdout /var/log/nginx/access.log \
   && ln -sf /dev/stderr /var/log/nginx/error.log
+
+COPY nginx.conf /etc/nginx/
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,118 @@
+
+#user  nobody;
+worker_processes  1;
+
+#error_log  logs/error.log;
+#error_log  logs/error.log  notice;
+#error_log  logs/error.log  info;
+
+#pid        logs/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    #keepalive_timeout  0;
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    server {
+        listen       80;
+        server_name  localhost;
+
+        #charset koi8-r;
+
+        #access_log  logs/host.access.log  main;
+
+        location / {
+            root   html;
+            index  index.html index.htm;
+        }
+
+        #error_page  404              /404.html;
+
+        # redirect server error pages to the static page /50x.html
+        #
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   html;
+        }
+
+        # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+        #
+        #location ~ \.php$ {
+        #    proxy_pass   http://127.0.0.1;
+        #}
+
+        # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+        #
+        #location ~ \.php$ {
+        #    root           html;
+        #    fastcgi_pass   127.0.0.1:9000;
+        #    fastcgi_index  index.php;
+        #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+        #    include        fastcgi_params;
+        #}
+
+        # deny access to .htaccess files, if Apache's document root
+        # concurs with nginx's one
+        #
+        #location ~ /\.ht {
+        #    deny  all;
+        #}
+    }
+
+
+    # another virtual host using mix of IP-, name-, and port-based configuration
+    #
+    #server {
+    #    listen       8000;
+    #    listen       somename:8080;
+    #    server_name  somename  alias  another.alias;
+
+    #    location / {
+    #        root   html;
+    #        index  index.html index.htm;
+    #    }
+    #}
+
+
+    # HTTPS server
+    #
+    server {
+        listen       443 quic;
+        server_name  localhost;
+        ssl_protocols TLSv1.2 TLSv1.3;
+
+        ssl_certificate      /etc/ssl/localhost.pem;
+        ssl_certificate_key  /etc/ssl/private/localhost.key;
+
+        ssl_session_cache    shared:SSL:1m;
+        ssl_session_timeout  5m;
+
+        ssl_ciphers  HIGH:!aNULL:!MD5;
+        ssl_prefer_server_ciphers  on;
+
+        location / {
+            root   /usr/share/nginx/html;
+            index  index.html index.htm;
+        }
+    }
+
+}


### PR DESCRIPTION
Hi, first of all, thanks for sharing this Dockerfile!

This pull request reduces the container size to 22.5MB using docker multistage build (See [Use multi-stage builds | Docker Documentation](https://docs.docker.com/develop/develop-images/multistage-build/).

```
$ docker images --format '{{.Size}}' nginx-http3
22.5MB
```

It also adds a self-signed certificate and `nginx.conf` to listen on port 443 with quic.